### PR TITLE
Refactoring windows-rs wrapper

### DIFF
--- a/examples/sample_dll.rs
+++ b/examples/sample_dll.rs
@@ -5,14 +5,14 @@ use std::thread::spawn;
 use bindings::Windows::Win32::System::SystemServices::{
     DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH, DLL_THREAD_ATTACH, DLL_THREAD_DETACH,
 };
-use mem::windows::wrappers::{DWORD, HMODULE, LPVOID};
+use mem::windows::wrappers::{HModule, DWORD, LPVOID};
 
 fn hack_thread() {
     println!("Hi from the sample dll");
 }
 
 #[no_mangle]
-pub extern "system" fn DllMain(module_handle: HMODULE, dw_reason: DWORD, lp_reserved: LPVOID) -> bool {
+pub extern "system" fn DllMain(module_handle: HModule, dw_reason: DWORD, lp_reserved : LPVOID) -> bool {
     match dw_reason {
         1u32 => {
             std::thread::spawn(|| hack_thread());

--- a/mem-macros/src/lib.rs
+++ b/mem-macros/src/lib.rs
@@ -1,10 +1,6 @@
 use proc_macro::TokenStream;
-use proc_macro2::Span;
-use quote::{quote, quote_spanned, ToTokens};
-use syn::{
-    punctuated::Punctuated, token::Token, Abi, Attribute, AttributeArgs, FnArg, Ident, ItemFn, LitStr, Pat, PatType, Token,
-    Type,
-};
+use quote::quote;
+use syn::{AttributeArgs, ItemFn};
 
 #[proc_macro_attribute]
 pub fn dll_main(args: TokenStream, input: TokenStream) -> TokenStream {
@@ -28,7 +24,7 @@ pub fn dll_main(args: TokenStream, input: TokenStream) -> TokenStream {
     create_main(input, args, is_async).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
-fn create_main(mut input: ItemFn, args: AttributeArgs, is_async: bool) -> Result<TokenStream, syn::Error> {
+fn create_main(mut input: ItemFn, _: AttributeArgs, is_async: bool) -> Result<TokenStream, syn::Error> {
     let original_body = &input.block;
     let brace_token = input.block.brace_token;
     if !is_async {

--- a/mem/bindings/build.rs
+++ b/mem/bindings/build.rs
@@ -1,30 +1,21 @@
 fn main() {
     windows::build!(
-        Windows::Win32::System::SystemServices::CHAR,
         Windows::Win32::Foundation::{INVALID_HANDLE_VALUE, CloseHandle},
 
-        Windows::Win32::System::Threading::{OpenProcess, GetCurrentProcess, PROCESS_ACCESS_RIGHTS,
-            CreateThread, THREAD_CREATION_FLAGS, CreateRemoteThread, WaitForSingleObject, PROCESS_ACCESS_RIGHTS},
+        Windows::Win32::System::Threading::{OpenProcess, GetCurrentProcess, PROCESS_ACCESS_RIGHTS,CreateThread, THREAD_CREATION_FLAGS, CreateRemoteThread, WaitForSingleObject, PROCESS_ACCESS_RIGHTS},
 
         Windows::Win32::System::LibraryLoader::{GetModuleHandleW, FreeLibraryAndExitThread, DisableThreadLibraryCalls, GetModuleHandleA, GetProcAddress},
 
-        Windows::Win32::System::SystemServices::{
-            DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH,
-            LPTHREAD_START_ROUTINE,
-            CHAR, DLL_THREAD_ATTACH, DLL_THREAD_DETACH},
+        Windows::Win32::System::SystemServices::{DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH, LPTHREAD_START_ROUTINE, CHAR, DLL_THREAD_ATTACH, DLL_THREAD_DETACH, CHAR},
 
-        Windows::Win32::System::LibraryLoader::DisableThreadLibraryCalls,
+        Windows::Win32::System::Diagnostics::Debug::{ReadProcessMemory, WriteProcessMemory, GetLastError},
 
-        Windows::Win32::System::Diagnostics::Debug::{ReadProcessMemory, WriteProcessMemory},
-
-        Windows::Win32::System::Diagnostics::ToolHelp::{CreateToolhelp32Snapshot, PROCESSENTRY32, CREATE_TOOLHELP_SNAPSHOT_FLAGS,
-            Process32First, Process32Next, MODULEENTRY32, Module32First, Module32Next, CREATE_TOOLHELP_SNAPSHOT_FLAGS},
+        Windows::Win32::System::Diagnostics::ToolHelp::{CreateToolhelp32Snapshot, PROCESSENTRY32, CREATE_TOOLHELP_SNAPSHOT_FLAGS, Process32First, Process32Next, MODULEENTRY32, Module32First, Module32Next, CREATE_TOOLHELP_SNAPSHOT_FLAGS},
 
         Windows::Win32::System::WindowsProgramming::{INFINITE},
 
         Windows::Win32::UI::KeyboardAndMouseInput::GetAsyncKeyState,
 
-        Windows::Win32::System::Memory::{VirtualProtect, VirtualProtectEx, VirtualQueryEx, VirtualAllocEx,
-              VirtualFreeEx}
+        Windows::Win32::System::Memory::{VirtualProtect, VirtualProtectEx, VirtualQueryEx, VirtualAllocEx, VirtualFreeEx},
     );
 }

--- a/mem/src/error.rs
+++ b/mem/src/error.rs
@@ -2,8 +2,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Handle was invalid")]
-    Handle,
+    #[error("Handle was invalid: {0}")]
+    Handle(u32),
     #[error(transparent)]
     Os(#[from] std::io::Error),
     #[error("Error converting C string to a rust &str")]
@@ -12,10 +12,16 @@ pub enum Error {
     ProcessNotFound,
     #[error(transparent)]
     NulError(#[from] std::ffi::NulError),
-    #[error("Couldn't write memory")]
-    MemoryWrite,
-    #[error("Couldn't find function in the process")]
-    ProcessAddress,
+    #[error("Couldn't find function in the process: {0}")]
+    ProcessAddress(u32),
+    #[error("Error allocating or deallocting: {0}")]
+    Allocation(u32),
+    #[error("Error pertaining to memory access: {0}")]
+    MemoryError(u32),
+    #[error("Error pertaining to processes: {0}")]
+    ProcessError(u32),
+    #[error("Timeout error")]
+    Timeout,
     #[error("DLL path doesn't exist")]
     DllPath,
     #[error("You must enable the feature for that render type")]

--- a/mem/src/external/mem.rs
+++ b/mem/src/external/mem.rs
@@ -1,10 +1,14 @@
 /*
 use std::ffi::c_void;
 
-use bindings::Windows::Win32::System::{
-    SystemServices::{HANDLE, INVALID_HANDLE_VALUE, LPTHREAD_START_ROUTINE, PAGE_EXECUTE_READWRITE, PAGE_TYPE},
-    Threading::PROCESS_ALL_ACCESS,
-    WindowsProgramming::INFINITE,
+use bindings::Windows::Win32::{
+    Foundation::HANDLE,
+    System::{
+        Memory::{PAGE_EXECUTE_READWRITE, PAGE_PROTECTION_FLAGS},
+        SystemServices::LPTHREAD_START_ROUTINE,
+        Threading::PROCESS_ALL_ACCESS,
+        WindowsProgramming::INFINITE,
+    },
 };
 
 use crate::{
@@ -13,7 +17,7 @@ use crate::{
         utils::{get_module_base, get_process_id},
         wrappers::{
             close_handle, create_remote_thread, open_process, ptr, read_process_memory, size_t, virtual_protect_ex,
-            wait_for_single_object, write_process_memory, DWORD, DWORD_PTR, LPCVOID, LPVOID,
+            wait_for_single_object, write_process_memory, DWORD_PTR, LPCVOID, LPVOID,
         },
     },
 };
@@ -25,11 +29,12 @@ pub struct Mem {
 
 #[cfg(feature = "external")]
 impl Mem {
+    /// # Errors
     pub fn new(process_name: &str) -> Result<Self, Error> {
         let process_id = get_process_id(process_name)?;
         let module_base_address = get_module_base(process_id, process_name)?;
 
-        let process = open_process(PROCESS_ALL_ACCESS, FALSE, process_id);
+        let process = open_process(PROCESS_ALL_ACCESS, false.into(), process_id);
 
         if process.is_null() {
             return Err(std::io::Error::last_os_error().into());
@@ -41,7 +46,8 @@ impl Mem {
         })
     }
 
-    pub fn write_value<T>(&self, pointer: ptr, output: T, relative: bool) -> bool {
+    /// # Errors
+    pub fn write_value<T>(&self, pointer: ptr, output: &T, relative: bool) -> Result<bool, Error> {
         let relative_value_address = if relative {
             pointer + self.module_base_address
         } else {
@@ -53,14 +59,15 @@ impl Mem {
         write_process_memory(
             self.process,
             relative_value_address as LPVOID,
-            (&output as *const T) as LPVOID,
+            (output as *const T) as LPVOID,
             std::mem::size_of::<T>() as usize,
             &mut bytes_written,
-        );
+        )?;
 
-        bytes_written != 0
+        Ok(bytes_written != 0)
     }
 
+    #[must_use]
     pub fn read_value<T>(&self, pointer: ptr, relative: bool) -> T {
         let relative_value_address = if relative {
             pointer + self.module_base_address
@@ -73,30 +80,33 @@ impl Mem {
         read_process_memory(
             self.process,
             relative_value_address as LPCVOID,
-            &mut buffer as *mut T as LPVOID,
+            (&mut buffer as *mut T).cast::<std::ffi::c_void>(),
             std::mem::size_of::<T>(),
-            0 as *mut size_t,
+            std::ptr::null_mut::<size_t>(),
         );
 
         buffer
     }
 
     /// Puts a NOP code at a memory address. A NOP will literally do nothing, it
-    /// is intended to replace a assembly instruction to make it no longer
+    /// is intended to replace an assembly instruction to make it no longer
     /// do anything yet still allow the process to compile.
-    pub fn nop(&self, address: *mut c_void, size: usize) {
-        let nop_array = vec![0; size];
+    ///
+    /// # Errors
+    pub fn nop(&self, address: *mut c_void, size: usize) -> Result<(), Error> {
+        let nop_array: Vec<usize> = vec![0; size];
 
         unsafe {
             std::ptr::write_bytes(nop_array.as_ptr() as *mut usize, 0x90, size);
         }
 
-        self.patch(address, nop_array.as_ptr() as *mut c_void, size);
+        self.patch(address, nop_array.as_ptr() as *mut c_void, size)
     }
 
     /// Idk if this will be used at all, maybe... Essentially you just create a
     /// thread for another process then your function will be called at that
     /// threads start routine.
+    /// # Errors
     pub fn call_function(&self, function: LPTHREAD_START_ROUTINE) -> Result<(), Error> {
         let thread_handle = create_remote_thread(
             self.process,
@@ -106,28 +116,25 @@ impl Mem {
             std::ptr::null_mut(),
             0,
             std::ptr::null_mut(),
-        );
+        )?;
 
-        if thread_handle == INVALID_HANDLE_VALUE {
-            return Err(Error::Handle);
-        }
-
-        wait_for_single_object(thread_handle, INFINITE);
-        close_handle(thread_handle);
+        wait_for_single_object(thread_handle, INFINITE)?;
+        close_handle(thread_handle)?;
 
         Ok(())
     }
 
-    pub fn patch(&self, address: *mut c_void, base: LPVOID, size: usize) {
-        let old_protect: *mut PAGE_TYPE = std::ptr::null_mut();
+    /// # Errors
+    pub fn patch(&self, address: *mut c_void, base: LPVOID, size: usize) -> Result<(), Error> {
+        let old_protect: *mut PAGE_PROTECTION_FLAGS = std::ptr::null_mut();
 
-        // Changes a memory regions protection so we can write to it.
-        virtual_protect_ex(self.process, address, size, PAGE_EXECUTE_READWRITE, old_protect);
+        // Changes a memory regions protection, so we can write to it.
+        virtual_protect_ex(self.process, address, size, PAGE_EXECUTE_READWRITE, old_protect)?;
 
-        write_process_memory(self.process, address, base, size, std::ptr::null_mut());
+        write_process_memory(self.process, address, base, size, std::ptr::null_mut())?;
 
         // Cleans up other virtual protect
-        virtual_protect_ex(self.process, address, size, unsafe { *old_protect }, old_protect);
+        virtual_protect_ex(self.process, address, size, unsafe { *old_protect }, old_protect)
     }
 }
 */

--- a/mem/src/injector.rs
+++ b/mem/src/injector.rs
@@ -1,21 +1,19 @@
-use std::{ffi::CString, ptr::null_mut};
+use std::ptr::null_mut;
 
-use bindings::Windows::Win32::{
-    Foundation::{CloseHandle, HINSTANCE, INVALID_HANDLE_VALUE, PSTR},
-    System::{
-        Diagnostics::Debug::WriteProcessMemory,
-        LibraryLoader::{GetModuleHandleA, GetProcAddress},
-        Memory::{VirtualAllocEx, VirtualFreeEx, MEM_COMMIT, MEM_RELEASE, MEM_RESERVE, PAGE_READWRITE},
-        Threading::PROCESS_ALL_ACCESS,
-    },
+use bindings::Windows::Win32::System::{
+    Memory::{MEM_COMMIT, MEM_RESERVE, PAGE_READWRITE},
+    Threading::PROCESS_ALL_ACCESS,
 };
 
 use crate::{
     error::Error,
-    windows::wrappers::{open_process, DWORD, LPVOID},
+    windows::wrappers::{
+        close_handle, create_remote_thread, get_module_handle, get_proc_address, open_process, virtual_alloc_ex,
+        write_process_memory, DWORD, LPVOID,
+    },
 };
 
-/// Several different methods of loading our library into the target process
+/// Several methods of loading our library into the target process
 pub enum InjectionMethod {
     /// This is the typical method when safety is not really a concern
     LoadLibrary,
@@ -60,7 +58,7 @@ pub struct Config {
 }
 
 impl Config {
-    fn max_stealth() -> Self {
+    const fn max_stealth() -> Self {
         Self {
             injection_method: InjectionMethod::ManualMap,
             execution_method: CodeExecutionMethod::ThreadHijack,
@@ -88,94 +86,35 @@ pub struct Injector {
 }
 
 impl Injector {
-    pub fn new(config: Config) -> Injector { Injector { config } }
+    #[must_use]
+    pub const fn new(config: Config) -> Self { Self { config } }
 
-    // TODO: Need to make the config properly work, currently it just uses a default
+    /// # Errors
     pub fn inject(&self, process_id: u32, dll_path: &str) -> Result<(), Error> {
-        let load_lib_address = get_fn_address("Kernel32.dll", "LoadLibraryA")?;
+        let load_lib_address = get_proc_address(get_module_handle("Kernel32.dll")?, "LoadLibraryA")?;
 
-        let dll_path_cstr = CString::new(dll_path)?;
-        let dll_path_size = dll_path_cstr.as_bytes_with_nul().len();
+        let dll_path_size = dll_path.as_bytes().len();
 
-        let process_handle = open_process(PROCESS_ALL_ACCESS, false.into(), process_id);
+        let process_handle = open_process(PROCESS_ALL_ACCESS, false, process_id);
 
-        if process_handle.is_invalid() {
-            return Err(Error::Handle);
-        }
+        let path = virtual_alloc_ex(
+            process_handle,
+            null_mut(),
+            dll_path_size,
+            MEM_RESERVE | MEM_COMMIT,
+            PAGE_READWRITE,
+        )?;
 
-        let path = unsafe {
-            // requires PROCESS_VM_OPERATION access right, this will just request an
-            // allocation to the memory of the process
-            VirtualAllocEx(
-                process_handle,
-                null_mut(),
-                dll_path_size,
-                MEM_RESERVE | MEM_COMMIT,
-                PAGE_READWRITE,
-            )
-        };
-
-        if path.is_null() {
-            return Err(std::io::Error::last_os_error().into());
-        }
-
-        // if this fails it will return 0 aka false
-        let success: bool = unsafe {
-            // requires PROCESS_VM_WRITE and PROCESS_VM_OPERATION access rights
-            WriteProcessMemory(
-                process_handle,
-                path,
-                dll_path_cstr.as_ptr() as LPVOID,
-                dll_path_size,
-                null_mut(),
-            )
-            .into()
-        };
-
-        if !success {
-            return Err(Error::MemoryWrite);
-        }
+        write_process_memory(process_handle, path, dll_path.as_ptr() as LPVOID, dll_path_size, null_mut())?;
 
         let thread_handle = unsafe {
             type StartRoutine = extern "system" fn(LPVOID) -> DWORD;
-            // we memcpy the loadlib addy to this, its very unsafe though
             let start_routine: StartRoutine = std::mem::transmute(load_lib_address);
-            bindings::Windows::Win32::System::Threading::CreateRemoteThread(
-                process_handle,
-                null_mut(),
-                0,
-                Some(start_routine),
-                path,
-                0,
-                null_mut(),
-            )
+            create_remote_thread(process_handle, null_mut(), 0, Some(start_routine), path, 0, null_mut())?
         };
 
-        //unsafe { VirtualFreeEx(process_handle, path, dll_path_size, MEM_RELEASE) };
-
-        if thread_handle == INVALID_HANDLE_VALUE {
-            return Err(Error::Handle);
-        }
-        unsafe { CloseHandle(thread_handle) };
+        close_handle(thread_handle)?;
 
         Ok(())
-    }
-}
-
-fn get_fn_address<'a>(module_name: &str, fn_name: &str) -> Result<u64, Error> {
-    let mod_str = CString::new(module_name)?;
-    let fn_str = CString::new(fn_name)?;
-
-    let module_handle = unsafe { GetModuleHandleA(PSTR(mod_str.into_raw() as _)) };
-
-    if module_handle.is_null() {
-        return Err(Error::Handle);
-    }
-
-    let function = unsafe { GetProcAddress(module_handle, PSTR(fn_str.into_raw() as _)) };
-
-    match function {
-        None => Err(Error::ProcessAddress),
-        Some(function) => Ok(function as u64),
     }
 }

--- a/mem/src/lib.rs
+++ b/mem/src/lib.rs
@@ -5,7 +5,8 @@
     non_snake_case,
     dead_code,
     clippy::cast_possible_wrap,
-    clippy::upper_case_acronyms
+    clippy::upper_case_acronyms,
+    clippy::not_unsafe_ptr_arg_deref
 )]
 
 #[cfg(not(target_os = "windows"))]

--- a/mem/src/macros/mod.rs
+++ b/mem/src/macros/mod.rs
@@ -1,7 +1,3 @@
-use bindings::Windows::Win32::System::SystemServices::{DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH};
-
-pub(crate) use crate::windows::wrappers::{close_handle, create_thread, DWORD, HMODULE, LPVOID};
-
 #[macro_use]
 mod cfg;
 

--- a/mem/src/windows/wrappers.rs
+++ b/mem/src/windows/wrappers.rs
@@ -1,20 +1,27 @@
-#![allow(clippy::not_unsafe_ptr_arg_deref)]
-
-use std::os::raw::*;
+//! `wrappers` is a "thin as possible" wrapper around windows-rs. It aims to be
+//! fast, while trying to remain as safe as possible, and being easy to use.
+//!
+//! Not all functions are designated as safe as without adding a significant
+//! amount of boilerplate will always be up to the caller to make sure UB can't
+//! happen. As time goes on we'll try to make as little functions unsafe.
+use std::os::raw::{c_ulong, c_void};
 
 use bindings::Windows::Win32::{
-    Foundation::{CloseHandle, BOOL, HANDLE, HINSTANCE},
+    Foundation::{CloseHandle, HANDLE, HINSTANCE},
     Security::SECURITY_ATTRIBUTES,
     System::{
         Diagnostics::{
-            Debug::{ReadProcessMemory, WriteProcessMemory},
+            Debug::{GetLastError, ReadProcessMemory, WriteProcessMemory},
             ToolHelp::{
                 CreateToolhelp32Snapshot, Module32First, Module32Next, Process32First, Process32Next,
                 CREATE_TOOLHELP_SNAPSHOT_FLAGS, MODULEENTRY32, PROCESSENTRY32,
             },
         },
-        LibraryLoader::{DisableThreadLibraryCalls, FreeLibraryAndExitThread, GetModuleHandleA},
-        Memory::{VirtualProtect, VirtualProtectEx, VirtualQueryEx, MEMORY_BASIC_INFORMATION, PAGE_PROTECTION_FLAGS},
+        LibraryLoader::{DisableThreadLibraryCalls, FreeLibraryAndExitThread, GetModuleHandleA, GetProcAddress},
+        Memory::{
+            VirtualAllocEx, VirtualFreeEx, VirtualProtect, VirtualProtectEx, VirtualQueryEx, MEMORY_BASIC_INFORMATION,
+            PAGE_PROTECTION_FLAGS, VIRTUAL_ALLOCATION_TYPE, VIRTUAL_FREE_TYPE,
+        },
         SystemServices::LPTHREAD_START_ROUTINE,
         Threading::{
             CreateRemoteThread, CreateThread, GetCurrentProcess, OpenProcess, WaitForSingleObject, PROCESS_ACCESS_RIGHTS,
@@ -24,7 +31,9 @@ use bindings::Windows::Win32::{
     UI::KeyboardAndMouseInput::GetAsyncKeyState,
 };
 
-/// size_t is a usize which will be 4 bytes for x86 and 8 bytes for x64
+use crate::error::Error;
+
+/// `size_t` is an usize which will be 4 bytes for x86 and 8 bytes for x64
 #[allow(non_camel_case_types)]
 pub type size_t = usize;
 /// used for pointers as types
@@ -39,60 +48,165 @@ pub type LPVOID = *mut c_void;
 pub type LPCVOID = *const c_void;
 pub type WCHAR = u16;
 pub type LPCWSTR = WCHAR;
-pub type HMODULE = isize;
 
-pub fn disable_thread_library_calls(module_handle: HMODULE) {
-    unsafe {
-        DisableThreadLibraryCalls(module_handle);
+/// `HandleInstance` is a handle to a module/instance. This handle is used for a
+/// lot of functions as they are used to identify a program that is loaded into
+/// memory.
+pub type HandleInstance = HINSTANCE;
+/// `Handle` is a handle to an object, and not specifically a program.
+pub type Handle = HANDLE;
+/// `HModule` is the base address of a DLL.
+pub type HModule = isize;
+/// Contains information about a range of pages in the virtual address space of
+/// a process.
+pub type MemoryBasicInformation = MEMORY_BASIC_INFORMATION;
+/// `PageProtectionFlags` is a variable that contains memory protection
+/// constants.
+pub type PageProtectionFlags = PAGE_PROTECTION_FLAGS;
+// TODO: DOCS cc: steele
+pub type WaitReturnCause = WAIT_RETURN_CAUSE;
+// TODO: DOCS cc: steele
+pub type VirtualFreeType = VIRTUAL_FREE_TYPE;
+// TODO: DOCS cc: steele
+pub type VirtualAllocationType = VIRTUAL_ALLOCATION_TYPE;
+// TODO: DOCS cc: steele
+pub type SecurityAttrivutes = SECURITY_ATTRIBUTES;
+// TODO: DOCS cc: steele
+pub type LPThreadStartRoutine = LPTHREAD_START_ROUTINE;
+// TODO: DOCS cc: steele
+pub type ThreadCreationFlags = THREAD_CREATION_FLAGS;
+// TODO: DOCS cc: steele
+pub type ProcessAccessRights = PROCESS_ACCESS_RIGHTS;
+// TODO: DOCS cc: steele
+pub type ProcessEntry32 = PROCESSENTRY32;
+// TODO: DOCS cc: steele
+pub type CreateToolhelpSnapshotFlags = CREATE_TOOLHELP_SNAPSHOT_FLAGS;
+// TODO: DOCS cc: steele
+pub type ModuleEntry32 = MODULEENTRY32;
+
+/// `get_module_handle` will get the handle of a module.
+///
+/// # Errors
+/// If the `hInstance` returned is NULL a `Error::Handle` is returned.
+pub fn get_module_handle(module_name: &str) -> Result<HandleInstance, Error> {
+    let hinstance = unsafe { GetModuleHandleA(module_name) };
+
+    if hinstance == HandleInstance::NULL {
+        Err(Error::Handle(unsafe { GetLastError().0 }))
+    } else {
+        Ok(hinstance)
     }
 }
 
-pub(crate) fn get_module_handle(module_name: &str) -> HINSTANCE { unsafe { GetModuleHandleA(module_name) } }
-
-pub(crate) fn virtual_query_ex(
-    process: HANDLE,
-    address: *const c_void,
-    buffer: *mut MEMORY_BASIC_INFORMATION,
+/// Retrieves information about a range of pages within the virtual address
+/// space of a specified process.
+///
+/// # Errors
+/// `Error::MemoryError` is returned if the function fails.
+pub fn virtual_query_ex(
+    process: Handle,
+    address: LPCVOID,
+    buffer: *mut MemoryBasicInformation,
     length: usize,
-) -> usize {
-    unsafe { VirtualQueryEx(process, address, buffer, length) }
+) -> Result<usize, Error> {
+    let num_bytes = unsafe { VirtualQueryEx(process, address, buffer, length) };
+    if num_bytes == 0 {
+        Err(Error::MemoryError(unsafe { GetLastError().0 }))
+    } else {
+        Ok(num_bytes)
+    }
 }
 
-pub(crate) fn get_async_key_state(key: i32) -> i16 { unsafe { GetAsyncKeyState(key) } }
+/// Determines whether a key is up or down at the time the function is called,
+/// and whether the key was pressed after a previous call to
+/// `get_async_key_state`.
+///
+/// # Errors
+/// If the function succeeds, the return value specifies whether the key was
+/// pressed since the last call to `get_async_key_state`, and whether the key is
+/// currently up or down. If the most significant bit is set, the key is down,
+/// and if the least significant bit is set, the key was pressed after the
+/// previous call to `get_async_key_state`. However, you should not rely on this
+/// last behavior.
+#[must_use]
+pub fn get_async_key_state(key: i32) -> i16 { unsafe { GetAsyncKeyState(key) } }
 
-pub(crate) fn virtual_protect_ex(
-    process: HANDLE,
-    address: *mut c_void,
+/// Changes the protection on a region of committed pages in the virtual address
+/// space of a specified process.
+///
+/// # Errors
+/// On error `Error::Allocation` is returned.
+pub fn virtual_protect_ex(
+    process: Handle,
+    address: LPVOID,
     size: usize,
-    new_protect: PAGE_PROTECTION_FLAGS,
-    old_protect: *mut PAGE_PROTECTION_FLAGS,
-) -> bool {
-    unsafe { VirtualProtectEx(process, address, size, new_protect, old_protect).into() }
+    new_protect: PageProtectionFlags,
+    old_protect: *mut PageProtectionFlags,
+) -> Result<(), Error> {
+    let res = unsafe { VirtualProtectEx(process, address, size, new_protect, old_protect) };
+
+    if res.as_bool() {
+        Ok(())
+    } else {
+        Err(Error::Allocation(unsafe { GetLastError().0 }))
+    }
 }
 
-pub(crate) fn virtual_protect(
-    address: *mut c_void,
+/// Changes the protection on a region of committed pages in the virtual address
+/// space of the calling process.
+///
+/// # Errors
+/// On error `Error::MemoryError` is returned.
+pub fn virtual_protect(
+    address: LPVOID,
     size: usize,
-    new_protect: PAGE_PROTECTION_FLAGS,
-    old_protect: *mut PAGE_PROTECTION_FLAGS,
-) -> bool {
-    unsafe { VirtualProtect(address, size, new_protect, old_protect).into() }
+    new_protect: PageProtectionFlags,
+    old_protect: *mut PageProtectionFlags,
+) -> Result<(), Error> {
+    let res = unsafe { VirtualProtect(address, size, new_protect, old_protect) };
+
+    if res.as_bool() {
+        Ok(())
+    } else {
+        Err(Error::MemoryError(unsafe { GetLastError().0 }))
+    }
 }
 
-pub(crate) fn wait_for_single_object(handle: HANDLE, milliseconds: u32) -> WAIT_RETURN_CAUSE {
-    unsafe { WaitForSingleObject(handle, milliseconds) }
-}
+/// Waits until the specified object is in the signaled state or the time-out
+/// interval elapses.
+///
+/// To enter an alertable wait state, use the `WaitForSingleObjectEx` function.
+/// To wait for multiple objects, use `WaitForMultipleObjects`.
+///
+/// # Errors
+/// If the function fails, `Error::Timeout` is returned.
+pub fn wait_for_single_object(handle: Handle, milliseconds: u32) -> Result<WaitReturnCause, Error> {
+    let res = unsafe { WaitForSingleObject(handle, milliseconds) };
 
-pub(crate) fn create_remote_thread(
-    process: HANDLE,
-    thread_attributes: *mut SECURITY_ATTRIBUTES,
+    if res == WaitReturnCause::from(0xFFFF_FFFF) {
+        Err(Error::Timeout)
+    } else {
+        Ok(res)
+    }
+}
+/// Creates a thread that runs in the virtual address space of another process.
+///
+/// Use the `CreateRemoteThreadEx` function to create a thread that runs in the
+/// virtual address space of another process and optionally specify extended
+/// attributes.
+///
+/// # Errors
+/// If the function fails, `Error::ProcessNotFound` is returned.
+pub fn create_remote_thread(
+    process: Handle,
+    thread_attributes: *mut SecurityAttrivutes,
     stack_size: usize,
-    start_address: Option<LPTHREAD_START_ROUTINE>,
-    parameter: *mut c_void,
+    start_address: Option<LPThreadStartRoutine>,
+    parameter: LPVOID,
     creation_flags: u32,
     thread_id: *mut u32,
-) -> HANDLE {
-    unsafe {
+) -> Result<Handle, Error> {
+    let handle = unsafe {
         CreateRemoteThread(
             process,
             thread_attributes,
@@ -102,18 +216,31 @@ pub(crate) fn create_remote_thread(
             creation_flags,
             thread_id,
         )
+    };
+
+    if handle == Handle::NULL {
+        Err(Error::ProcessError(unsafe { GetLastError().0 }))
+    } else {
+        Ok(handle)
     }
 }
-
-pub(crate) fn create_thread(
-    thread_attributes: *mut SECURITY_ATTRIBUTES,
+/// Creates a thread to execute within the virtual address space of the calling
+/// process.
+///
+/// To create a thread that runs in the virtual address space of another
+/// process, use the `create_remote_thread` function.
+///
+/// # Errors
+/// If the function fails, `Error::ProcessNotFound` is returned.
+pub fn create_thread(
+    thread_attributes: *mut SecurityAttrivutes,
     stack_size: usize,
-    start_address: Option<LPTHREAD_START_ROUTINE>,
-    parameter: *mut c_void,
-    creation_flags: THREAD_CREATION_FLAGS,
+    start_address: Option<LPThreadStartRoutine>,
+    parameter: LPVOID,
+    creation_flags: ThreadCreationFlags,
     thread_id: *mut u32,
-) -> HANDLE {
-    unsafe {
+) -> Result<Handle, Error> {
+    let res = unsafe {
         CreateThread(
             thread_attributes,
             stack_size,
@@ -122,65 +249,218 @@ pub(crate) fn create_thread(
             creation_flags,
             thread_id,
         )
+    };
+
+    if res == Handle::NULL {
+        Err(Error::ProcessError(unsafe { GetLastError().0 }))
+    } else {
+        Ok(res)
     }
 }
 
-pub(crate) fn close_handle(handle: HANDLE) -> bool { unsafe { CloseHandle(handle).into() } }
+/// Closes an open object handle.
+///
+/// # Errors
+/// If the function fails, `Error::Handle` is returned.
+pub fn close_handle(handle: Handle) -> Result<(), Error> {
+    let res = unsafe { CloseHandle(handle) };
 
-pub(crate) fn get_current_process() -> HANDLE { unsafe { GetCurrentProcess() } }
+    if res.as_bool() {
+        Ok(())
+    } else {
+        Err(Error::Handle(unsafe { GetLastError().0 }))
+    }
+}
 
-pub(crate) fn free_library_and_exit_thread(module_handle: HINSTANCE, exit_code: DWORD) {
+/// Retrieves a pseudo handle for the current process.
+#[must_use]
+pub fn get_current_process() -> Handle { unsafe { GetCurrentProcess() } }
+
+/// Decrements the reference count of a loaded dynamic-link library (DLL) by
+/// one, then calls `ExitThread` to terminate the calling thread. The function
+/// does not return.
+pub fn free_library_and_exit_thread(module_handle: HandleInstance, exit_code: DWORD) {
     unsafe {
         FreeLibraryAndExitThread(module_handle, exit_code);
     }
 }
 
-/// Opens a process with the desired rights so you can perform actions upon it.
-pub(crate) fn open_process(desired_access: PROCESS_ACCESS_RIGHTS, inherit_handle: BOOL, process_id: DWORD) -> HANDLE {
+/// Opens an existing local process object.
+pub(crate) fn open_process(desired_access: ProcessAccessRights, inherit_handle: bool, process_id: DWORD) -> Handle {
     unsafe { OpenProcess(desired_access, inherit_handle, process_id) }
 }
 
-/// Creates a snapshot of current processes and etc.
-pub(crate) fn create_tool_help32_snapshot(flags: CREATE_TOOLHELP_SNAPSHOT_FLAGS, process_id: DWORD) -> HANDLE {
-    unsafe { CreateToolhelp32Snapshot(flags, process_id) }
+/// Takes a snapshot of the specified processes, as well as the heaps, modules,
+/// and threads used by these processes.
+///
+/// # Errors
+/// If the function fails, `Error::MemoryError` is returned.
+pub fn create_tool_help32_snapshot(flags: CreateToolhelpSnapshotFlags, process_id: DWORD) -> Result<Handle, Error> {
+    let res = unsafe { CreateToolhelp32Snapshot(flags, process_id) };
+    if res == Handle::INVALID {
+        Err(Error::MemoryError(unsafe { GetLastError().0 }))
+    } else {
+        Ok(res)
+    }
 }
 
-pub(crate) fn module32_first(snapshot: HANDLE, module_entry: &mut MODULEENTRY32) -> bool {
-    unsafe { Module32First(snapshot, module_entry).into() }
+/// Retrieves information about the first module associated with a process.
+///
+/// # Errors
+/// If the function fails, `Error::MemoryError` is returned.
+pub fn module32_first(snapshot: Handle, module_entry: &mut ModuleEntry32) -> Result<(), Error> {
+    let res = unsafe { Module32First(snapshot, module_entry) };
+    if res.as_bool() {
+        Ok(())
+    } else {
+        Err(Error::MemoryError(unsafe { GetLastError().0 }))
+    }
 }
 
-pub(crate) fn module32_next(snapshot: HANDLE, module_entry: &mut MODULEENTRY32) -> bool {
-    unsafe { Module32Next(snapshot, module_entry).into() }
+/// Retrieves information about the next module associated with a process or
+/// thread.
+///
+/// # Errors
+/// If the function fails, `Error::MemoryError` is returned.
+pub fn module32_next(snapshot: Handle, module_entry: &mut ModuleEntry32) -> Result<(), Error> {
+    let res = unsafe { Module32Next(snapshot, module_entry) };
+    if res.as_bool() {
+        Ok(())
+    } else {
+        Err(Error::MemoryError(unsafe { GetLastError().0 }))
+    }
 }
 
-/// Gets the first process to start process enumeration.
-pub(crate) fn process32_first(snapshot: HANDLE, process_entry: &mut PROCESSENTRY32) -> bool {
-    unsafe { Process32First(snapshot, process_entry).into() }
+/// Retrieves information about the first process encountered in a system
+/// snapshot.
+///
+/// # Errors
+/// If the function fails, `Error::MemoryError` is returned.
+pub fn process32_first(snapshot: Handle, process_entry: &mut ProcessEntry32) -> Result<(), Error> {
+    let res = unsafe { Process32First(snapshot, process_entry) };
+    if res.as_bool() {
+        Ok(())
+    } else {
+        Err(Error::MemoryError(unsafe { GetLastError().0 }))
+    }
 }
 
-/// Used to enumerate processes with usage of CreateToolhelp32Snapshot.
-pub(crate) fn process32_next(snapshot: HANDLE, process_entry: &mut PROCESSENTRY32) -> bool {
-    unsafe { Process32Next(snapshot, process_entry).into() }
+/// Retrieves information about the next process recorded in a system snapshot.
+///
+/// # Errors
+/// If the function fails, `Error::MemoryError` is returned.
+pub fn process32_next(snapshot: Handle, process_entry: &mut ProcessEntry32) -> Result<(), Error> {
+    let res = unsafe { Process32Next(snapshot, process_entry) };
+    if res.as_bool() {
+        Ok(())
+    } else {
+        Err(Error::MemoryError(unsafe { GetLastError().0 }))
+    }
 }
 
-/// Used to write to the memory of a process.
-pub(crate) fn write_process_memory(
-    process_handle: HANDLE,
+/// Writes data to an area of memory in a specified process. The entire area to
+/// be written to must be accessible or the operation fails.
+///
+/// # Errors
+/// If the function fails, `Error::MemoryError` is returned.
+pub fn write_process_memory(
+    process_handle: Handle,
     base_address: LPVOID,
     buffer: LPCVOID,
     size: size_t,
     number_of_bytes_written: *mut size_t,
-) -> bool {
-    unsafe { WriteProcessMemory(process_handle, base_address, buffer, size, number_of_bytes_written).into() }
+) -> Result<(), Error> {
+    let result = unsafe { WriteProcessMemory(process_handle, base_address, buffer, size, number_of_bytes_written) };
+    if result.as_bool() {
+        Ok(())
+    } else {
+        Err(Error::MemoryError(unsafe { GetLastError().0 }))
+    }
 }
 
-/// Used to read the memory of a process.
-pub(crate) fn read_process_memory(
-    process_handle: HANDLE,
+/// Reads data from an area of memory in a specified process.
+///
+/// # Errors
+/// If the function fails, `Error::MemoryError` is returned.
+pub fn read_process_memory(
+    process_handle: Handle,
     base_address: LPCVOID,
     buffer: LPVOID,
     size: size_t,
     number_of_bytes_written: *mut size_t,
-) -> bool {
-    unsafe { ReadProcessMemory(process_handle, base_address, buffer, size, number_of_bytes_written).into() }
+) -> Result<(), Error> {
+    let res = unsafe { ReadProcessMemory(process_handle, base_address, buffer, size, number_of_bytes_written) };
+    if res.as_bool() {
+        Ok(())
+    } else {
+        Err(Error::MemoryError(unsafe { GetLastError().0 }))
+    }
+}
+
+/// Retrieves the address of an exported function or variable from the specified
+/// dynamic-link library (DLL).
+///
+/// # Errors
+/// If the function fails, `Error::ProcessAddress` is returned.
+pub fn get_proc_address(hmodule: HINSTANCE, lpprocname: &str) -> Result<usize, Error> {
+    let function_address =
+        unsafe { GetProcAddress(hmodule, lpprocname) }.ok_or_else(|| Error::ProcessAddress(unsafe { GetLastError().0 }))?;
+
+    Ok(function_address as usize)
+}
+
+/// Reserves, commits, or changes the state of a region of memory within the
+/// virtual address space of a specified process. The function initializes the
+/// memory it allocates to zero.
+///
+/// # Errors
+/// If the function fails, `Error::MemoryError` is returned.
+pub fn virtual_alloc_ex(
+    handle: Handle,
+    lpaddress: *mut c_void,
+    dwsize: usize,
+    flallocation: VirtualAllocationType,
+    flprotect: PageProtectionFlags,
+) -> Result<*mut c_void, Error> {
+    let res = unsafe { VirtualAllocEx(handle, lpaddress, dwsize, flallocation, flprotect) };
+
+    if res.is_null() {
+        Err(Error::MemoryError(unsafe { GetLastError().0 }))
+    } else {
+        Ok(res)
+    }
+}
+
+/// Releases, decommits, or releases and decommits a region of memory within the
+/// virtual address space of a specified process.
+///
+/// # Errors
+/// If the function fails, `Error::MemoryError` is returned.
+pub fn virtual_free_ex(
+    hprocess: Handle,
+    lpaddress: *mut c_void,
+    dwsize: usize,
+    dwfreetype: VirtualFreeType,
+) -> Result<(), Error> {
+    let result = unsafe { VirtualFreeEx(hprocess, lpaddress, dwsize, dwfreetype) };
+    if result.as_bool() {
+        Ok(())
+    } else {
+        Err(Error::MemoryError(unsafe { GetLastError().0 }))
+    }
+}
+
+/// Disables the `DLL_THREAD_ATTACH` and `DLL_THREAD_DETACH` notifications for
+/// the specified dynamic-link library (DLL). This can reduce the size of the
+/// working set for some applications.
+///
+/// # Errors
+/// If the function fails, `Error::Handle` is returned.
+pub fn disable_thread_library_calls(module_handle: HandleInstance) -> Result<(), Error> {
+    let result = unsafe { DisableThreadLibraryCalls(module_handle) };
+    if result.as_bool() {
+        Ok(())
+    } else {
+        Err(Error::Handle(unsafe { GetLastError().0 }))
+    }
 }


### PR DESCRIPTION
This PR will add docs to all the wrapper functions, change over anything internal to use the wrapper over windows-rs directly, and other house keeping things to make the library easier to use.

- [x] Add documentation to all public functions
- [ ] Mark wrapper functions as either unsafe or wrap them in a safe way
- [x] Create types for export/use that will convert to proper windows-rs types
- [x] Resolve clippy lints